### PR TITLE
feat: make the diagnostic codestring configurable

### DIFF
--- a/doc/diag_ignore.nvim.txt
+++ b/doc/diag_ignore.nvim.txt
@@ -28,6 +28,7 @@ The default options are:
       ignores = {
         python = { 'endline',  ' # pyright: ignore[', ']' },
         lua =    { 'prevline', '---@diagnostic disable-next-line: ' },
+        go =    { 'endline', ' // nolint ', '', ', ', 'source' },
       },
     },
 <
@@ -35,11 +36,12 @@ The default options are:
 The `ignores` option lists the supported filetypes. Each value is a table:
 
 >lua
-    [filetype] = { type, prefix, suffix, joiner }
+    [filetype] = { type, prefix, suffix, joiner, diagnostic_code }
 <
 
 If `suffix` is `nil`, the default is `''` (empty string).
 If `joiner` is `nil`, the default is `', '` (comma and space).
+If `diagnostic_code` is `nil`, the default is `'code'`.
 
 If `type` is `'endline'`, the annotation will be appended to the current line.
 For example, in Python, invoking `diag_ignore.nvim` on


### PR DESCRIPTION
minimal repro:
init.lua:
```
local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
if not (vim.uv or vim.loop).fs_stat(lazypath) then
	vim.fn.system({
		"git",
		"clone",
		"--filter=blob:none",
		"https://github.com/folke/lazy.nvim.git",
		"--branch=stable", -- latest stable release
		lazypath,
	})
end
vim.opt.rtp:prepend(lazypath)
vim.g.mapleader = " " -- Make sure to set `mapleader` before lazy so your mappings are correct

require("lazy").setup({
	{
		"mfussenegger/nvim-lint",
		config = function()
			require("lint").linters_by_ft = {
				go = { "golangcilint" },
			}
			vim.api.nvim_create_autocmd({ "BufWritePost", "BufEnter" }, {
				group = vim.api.nvim_create_augroup("lint", { clear = true }),
				callback = function()
					require("lint").try_lint()
				end,
			})
		end,
	},
	{
		"arnevm123/diag_ignore.nvim",
		branch = "make-codestr-source-configurable",
		keys = {
			{ "<Leader>ci", "<Plug>(diag_ignore)", mode = "n", desc = "Diagnostic: ignore" },
		},
		opts = {},
	},
})

```

main.go:
```
local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
if not (vim.uv or vim.loop).fs_stat(lazypath) then
	vim.fn.system({
		"git",
		"clone",
		"--filter=blob:none",
		"https://github.com/folke/lazy.nvim.git",
		"--branch=stable", -- latest stable release
		lazypath,
	})
end
vim.opt.rtp:prepend(lazypath)
vim.g.mapleader = " " -- Make sure to set `mapleader` before lazy so your mappings are correct

require("lazy").setup({
	{
		"mfussenegger/nvim-lint",
		config = function()
			require("lint").linters_by_ft = {
				go = { "golangcilint" },
			}
			vim.api.nvim_create_autocmd({ "BufWritePost", "BufEnter" }, {
				group = vim.api.nvim_create_augroup("lint", { clear = true }),
				callback = function()
					require("lint").try_lint()
				end,
			})
		end,
	},
	{
		"arnevm123/diag_ignore.nvim",
		branch = "make-codestr-source-configurable",
		keys = {
			{ "<Leader>ci", "<Plug>(diag_ignore)", mode = "n", desc = "Diagnostic: ignore" },
		},
		opts = {},
	},
})

```
